### PR TITLE
fix husky initialization step for windows

### DIFF
--- a/src/presets/ghost-gulp-rollup/ghost-gulp-rollup-preset.ts
+++ b/src/presets/ghost-gulp-rollup/ghost-gulp-rollup-preset.ts
@@ -95,13 +95,8 @@ export class GhostGulpRollupPreset implements Preset {
   async getPostInstallationCommands(): Promise<string[]> {
     const npx = this.options.packageManager === 'npm' ? 'npx' : 'yarn';
     const npmRun = this.options.packageManager === 'npm' ? 'npm run' : 'yarn';
-    const huskyQuote = process.platform === 'win32' ? '\\"' : '"';
     return this.ghostGulpRollupOptions.useLinting && this.options.deps && this.options.git
-      ? [
-          `${npx} husky install`,
-          `${npx} husky add .husky/pre-commit ${huskyQuote}${npx} lint-staged${huskyQuote}`,
-          `${npmRun} format`,
-        ]
+      ? [`${npx} husky install`, `${npx} husky add .husky/pre-commit "${npx} lint-staged"`, `${npmRun} format`]
       : [];
   }
 


### PR DESCRIPTION
Generates the following file with cmd.

`.husky/pre-commit`
```
#!/bin/sh
. "$(dirname "$0")/_/husky.sh"

npx lint-staged

```

Should compare to what is in a module project generated on unix.

Fixes #19 