### PR TITLE
fix: add strict null checks to tsconfig

### DIFF
--- a/template/ghost-gulp-rollup/tsconfig.json.njk
+++ b/template/ghost-gulp-rollup/tsconfig.json.njk
@@ -7,6 +7,7 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
+    "strictNullChecks": true,
     "sourceMap": true
   },
   "include": ["src"]


### PR DESCRIPTION
With 0.8.x types, `"strictNullChecks": true,` is required in the tsconfig.